### PR TITLE
Add root index.html to fix GitHub Pages 404

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pokémon Chess on Canvas</title>
+    <link rel="stylesheet" href="public/styles.css">
+</head>
+<body>
+    <div class="card">
+        <header>
+            <h1>Pokémon Chess on Canvas</h1>
+            <p>Choose your Pokémon and battle!</p>
+        </header>
+
+        <canvas id="gameCanvas" width="600" height="600"></canvas>
+    </div>
+
+    <script src="public/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add root `index.html` so GitHub Pages serves project instead of returning 404

## Testing
- `python -m py_compile backend/app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897a37531108327b5b11476fda53e21