### PR TITLE
Add Pokémon type selection and battle mechanics

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,15 @@
     <link rel="stylesheet" href="public/styles.css">
 </head>
 <body>
+    <div id="startScreen" class="overlay">
+        <div class="modal">
+            <h2>Select Your Pokémon Type</h2>
+            <button class="type-btn" data-type="fire">Fire</button>
+            <button class="type-btn" data-type="water">Water</button>
+            <button class="type-btn" data-type="grass">Grass</button>
+        </div>
+    </div>
+
     <div class="card">
         <header>
             <h1>Pokémon Chess on Canvas</h1>
@@ -16,6 +25,15 @@
         <canvas id="gameCanvas" width="600" height="600"></canvas>
     </div>
 
+    <div id="battleModal" class="overlay hidden">
+        <div class="modal">
+            <h2>Battle!</h2>
+            <p>Choose your move:</p>
+            <div id="moveButtons"></div>
+        </div>
+    </div>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/chess.js/1.0.0/chess.min.js"></script>
     <script src="public/script.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,15 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+    <div id="startScreen" class="overlay">
+        <div class="modal">
+            <h2>Select Your Pokémon Type</h2>
+            <button class="type-btn" data-type="fire">Fire</button>
+            <button class="type-btn" data-type="water">Water</button>
+            <button class="type-btn" data-type="grass">Grass</button>
+        </div>
+    </div>
+
     <div class="card">
         <header>
             <h1>Pokémon Chess on Canvas</h1>
@@ -16,6 +25,15 @@
         <canvas id="gameCanvas" width="600" height="600"></canvas>
     </div>
 
+    <div id="battleModal" class="overlay hidden">
+        <div class="modal">
+            <h2>Battle!</h2>
+            <p>Choose your move:</p>
+            <div id="moveButtons"></div>
+        </div>
+    </div>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/chess.js/1.0.0/chess.min.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,69 +1,131 @@
-// Canvas setup
 const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
-
-// Chessboard setup
 const boardSize = 8;
 const cellSize = canvas.width / boardSize;
 
-// Images for Pokémon pieces
-const pokemonImages = {
-    charmander: new Image(),
-    squirtle: new Image()
+const startScreen = document.getElementById('startScreen');
+const battleModal = document.getElementById('battleModal');
+const moveButtonsDiv = document.getElementById('moveButtons');
+
+const pieceSets = {
+  fire: {k:'charizard', q:'ninetales', r:'arcanine', b:'magmar', n:'rapidash', p:'charmander'},
+  water:{k:'blastoise', q:'milotic', r:'gyarados', b:'starmie', n:'lapras', p:'squirtle'},
+  grass:{k:'venusaur', q:'lilligant', r:'torterra', b:'roserade', n:'sawsbuck', p:'bulbasaur'}
 };
-
-pokemonImages.charmander.src = "https://img.pokemondb.net/artwork/large/charmander.jpg";
-pokemonImages.squirtle.src = "https://img.pokemondb.net/artwork/large/squirtle.jpg";
-
-// Array to hold the positions of pieces
-let pieces = [
-    { type: 'pawn', color: 'white', x: 0, y: 1, image: pokemonImages.charmander },
-    { type: 'pawn', color: 'white', x: 1, y: 1, image: pokemonImages.squirtle }
-];
-
-// Track the selected piece
-let selectedPiece = null;
-
-// Draw the board and pieces on the canvas
-function drawBoard() {
-    for (let row = 0; row < boardSize; row++) {
-        for (let col = 0; col < boardSize; col++) {
-            ctx.fillStyle = (row + col) % 2 === 0 ? '#f0f8ff' : '#2f4f4f'; 
-            ctx.fillRect(col * cellSize, row * cellSize, cellSize, cellSize);
-
-            ctx.strokeStyle = '#333';
-            ctx.strokeRect(col * cellSize, row * cellSize, cellSize, cellSize);
-        }
-    }
-
-    pieces.forEach(piece => {
-        ctx.drawImage(piece.image, piece.x * cellSize, piece.y * cellSize, cellSize, cellSize);
-    });
-}
-
-// Handle mouse clicks on the canvas
-canvas.addEventListener('click', (e) => {
-    const x = Math.floor(e.offsetX / cellSize);
-    const y = Math.floor(e.offsetY / cellSize);
-
-    const clickedPiece = pieces.find(piece => piece.x === x && piece.y === y);
-
-    if (clickedPiece) {
-        if (selectedPiece) {
-            selectedPiece.x = x;
-            selectedPiece.y = y;
-            selectedPiece = null;
-        } else {
-            selectedPiece = clickedPiece;
-        }
-    } else if (selectedPiece) {
-        selectedPiece.x = x;
-        selectedPiece.y = y;
-        selectedPiece = null;
-    }
-
-    drawBoard();
+const types = Object.keys(pieceSets);
+const images = {};
+types.forEach(type=>{
+  images[type] = {};
+  Object.entries(pieceSets[type]).forEach(([key,name])=>{
+    const img = new Image();
+    img.src = `https://img.pokemondb.net/artwork/large/${name}.jpg`;
+    images[type][key]=img;
+  });
 });
 
-// Initial draw
+let playerType = null;
+let aiType = null;
+
+const game = new Chess();
+let selectedSquare = null;
+
+document.querySelectorAll('.type-btn').forEach(btn=>{
+  btn.addEventListener('click', ()=>{
+    playerType = btn.dataset.type;
+    const others = types.filter(t=>t!==playerType);
+    aiType = others[Math.floor(Math.random()*others.length)];
+    startScreen.classList.add('hidden');
+    drawBoard();
+  });
+});
+
+canvas.addEventListener('click', e=>{
+  if (!playerType || !battleModal.classList.contains('hidden')) return;
+  const x = Math.floor(e.offsetX / cellSize);
+  const y = Math.floor(e.offsetY / cellSize);
+  const file = 'abcdefgh'[x];
+  const rank = 8 - y;
+  const square = file + rank;
+  if (!selectedSquare) {
+    const piece = game.get(square);
+    if (piece && piece.color === 'w') selectedSquare = square;
+  } else {
+    const move = game.move({from:selectedSquare, to:square, promotion:'q'});
+    selectedSquare = null;
+    if (move) {
+      if (move.captured) {
+        resolveBattle('player', move, ()=>{
+          drawBoard();
+          if (!game.game_over()) makeAIMove();
+        });
+      } else {
+        drawBoard();
+        if (!game.game_over()) makeAIMove();
+      }
+    } else {
+      drawBoard();
+    }
+  }
+});
+
+function drawBoard() {
+  for (let row=0; row<boardSize; row++) {
+    for (let col=0; col<boardSize; col++) {
+      ctx.fillStyle = (row+col)%2===0 ? '#f0f8ff' : '#2f4f4f';
+      ctx.fillRect(col*cellSize, row*cellSize, cellSize, cellSize);
+    }
+  }
+  const board = game.board();
+  for (let row=0; row<8; row++) {
+    for (let col=0; col<8; col++) {
+      const piece = board[row][col];
+      if (piece) {
+        const set = piece.color==='w' ? images[playerType] : images[aiType];
+        const img = set[piece.type];
+        if (img.complete) {
+          ctx.drawImage(img, col*cellSize, row*cellSize, cellSize, cellSize);
+        } else {
+          img.onload = ()=>ctx.drawImage(img, col*cellSize, row*cellSize, cellSize, cellSize);
+        }
+      }
+    }
+  }
+}
+
+function makeAIMove() {
+  const moves = game.moves({verbose:true});
+  if (moves.length === 0) return;
+  const move = moves[Math.floor(Math.random()*moves.length)];
+  game.move(move);
+  if (move.captured) {
+    resolveBattle('ai', move, ()=>{ drawBoard(); });
+  } else {
+    drawBoard();
+  }
+}
+
+function resolveBattle(attacker, move, callback) {
+  battleModal.classList.remove('hidden');
+  moveButtonsDiv.innerHTML = '';
+  const battleMoves = ['Move 1','Move 2','Move 3','Move 4'];
+  battleMoves.forEach(m=>{
+    const btn = document.createElement('button');
+    btn.textContent = m;
+    btn.className = 'battle-move';
+    btn.onclick = ()=>{
+      battleModal.classList.add('hidden');
+      const attackerWins = Math.random() < 0.5;
+      if (!attackerWins) {
+        game.undo();
+        game.remove(move.from);
+        const turn = game.turn();
+        const fen = game.fen().replace(` ${turn} `, ` ${turn==='w'?'b':'w'} `);
+        game.load(fen);
+      }
+      callback();
+    };
+    moveButtonsDiv.appendChild(btn);
+  });
+}
+
 drawBoard();

--- a/public/styles.css
+++ b/public/styles.css
@@ -39,3 +39,33 @@ header p {
     color: #555;
     margin-top: 0.5rem;
 }
+
+.overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 10;
+}
+
+.modal {
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    text-align: center;
+}
+
+.type-btn, .battle-move {
+    margin: 5px;
+    padding: 10px 20px;
+    cursor: pointer;
+}
+
+.hidden {
+    display: none;
+}


### PR DESCRIPTION
## Summary
- allow players to choose a Pokémon type before starting
- include chess.js powered board with Pokémon pieces and random AI type
- trigger simple battle modal with four move options whenever a capture occurs

## Testing
- `python -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_689864b4630083279db54a974cd85484